### PR TITLE
Initial Spring Boot project setup for MES refactoring

### DIFF
--- a/mes-springboot-application/mes-app-core/pom.xml
+++ b/mes-springboot-application/mes-app-core/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.qcadoo.mes</groupId>
+        <artifactId>mes-springboot-application</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mes-app-core</artifactId>
+    <packaging>jar</packaging> <!-- Core application will be a JAR -->
+
+    <name>Qcadoo MES Spring Boot Core</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- This configuration ensures that 'mvn package' creates an executable JAR
+                     only for this module if it were run as the main application.
+                     However, for a multi-module project, typically the assembly is done
+                     at the parent level or a dedicated application packaging module.
+                     For now, this is fine for the core app module. -->
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mes-springboot-application/mes-app-core/src/main/java/com/qcadoo/mes/springboot/MesSpringbootApplication.java
+++ b/mes-springboot-application/mes-app-core/src/main/java/com/qcadoo/mes/springboot/MesSpringbootApplication.java
@@ -1,0 +1,13 @@
+package com.qcadoo.mes.springboot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MesSpringbootApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MesSpringbootApplication.class, args);
+    }
+
+}

--- a/mes-springboot-application/mes-app-core/src/main/resources/application.properties
+++ b/mes-springboot-application/mes-app-core/src/main/resources/application.properties
@@ -1,0 +1,99 @@
+# Spring Boot application properties
+
+# Server Properties
+server.port=8080
+
+# Application General Properties (migrated from app.properties)
+spring.application.name=mes-springboot-application
+# Example: qcadoo.mes.display-name=Qcadoo MES Spring Boot
+# Example: spring.web.locale=pl
+# Other app.properties will be migrated as corresponding features are implemented
+
+# Datasource Properties (migrated from db.properties)
+spring.datasource.url=jdbc:postgresql://localhost:5432/mes_db_springboot
+spring.datasource.username=mes_user
+spring.datasource.password=mes_password
+spring.datasource.driver-class-name=org.postgresql.Driver
+# HikariCP is the default connection pool in Spring Boot 2+
+spring.datasource.hikari.maximum-pool-size=15
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.idle-timeout=600000
+spring.datasource.hikari.max-lifetime=1800000
+
+# JPA / Hibernate Properties (migrated from db.properties)
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update # or validate, none, create, create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.generate_statistics=false
+# Spring Boot 2.x+ enables second-level cache via spring.jpa.properties.hibernate.cache.use_second_level_cache=true
+# and spring.jpa.properties.hibernate.cache.use_query_cache=true
+# along with a cache provider like EhCache or Hazelcast.
+# For now, leaving these out until a cache provider is explicitly added.
+# spring.jpa.properties.hibernate.cache.provider_class=org.hibernate.cache.HashtableCacheProvider # Deprecated, use region factory
+# spring.jpa.properties.hibernate.cache.region.factory_class= # e.g., org.hibernate.cache.ehcache.EhCacheRegionFactory
+
+# Mail Properties (migrated from mail.properties)
+spring.mail.host=smtp.example.com
+spring.mail.port=587
+spring.mail.username=user@example.com
+spring.mail.password=secret
+spring.mail.protocol=smtp
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true # For TLS
+# spring.mail.properties.mail.smtp.ssl.enable=true # For SSL, if needed
+# spring.mail.properties.mail.smtp.protocols=TLSv1.2
+spring.mail.test-connection=false # Set to true to test mail server connection on startup
+
+# Logging Configuration
+logging.level.root=INFO
+logging.level.com.qcadoo.mes.springboot=DEBUG
+logging.level.org.springframework.web=INFO
+logging.level.org.hibernate=INFO
+# logging.file.name=logs/mes-springboot.log # Example: to log to a file
+# logging.file.path= # Define path if logging.file.name is just a name
+
+# Placeholder for Connector Properties (from connectors.properties)
+# These will be environment-specific and should use Spring Profiles (e.g., application-dev.properties)
+# Example: qcadoo.connector.scada.location=
+# Example: qcadoo.connector.scada.username=
+# Example: qcadoo.connector.pipedrive.apiToken=
+
+# Placeholder for Mailing Properties (from mailing.properties)
+# Example: qcadoo.mailing.delivery-template-email=
+# Example: qcadoo.mailing.sendinblue.apikey=
+
+# Placeholder for Report Properties (from report.properties)
+# Example: qcadoo.report.path=
+# Example: qcadoo.report.font-path=
+
+# ESAPI Properties (from .esapi/ESAPI.properties and validation.properties)
+# These are critical and require special handling for security and loading.
+# They will be addressed in a dedicated step.
+# Key properties to consider for secure management:
+# Encryptor.MasterKey
+# Encryptor.MasterSalt
+# The ESAPI properties files themselves might need to be loaded via a custom mechanism
+# or by ensuring ESAPI can find them in its expected location if ESAPI is retained.
+
+# Default locale from app.properties
+# spring.web.locale=pl # Example, if 'pl' was the default
+
+# Custom application properties from app.properties can be prefixed
+# qcadoo.mes.applicationDisplayName=TEST QCD MES Spring Boot
+# qcadoo.mes.ignoreMissingTranslations=true
+# qcadoo.mes.useCustomTranslations=false
+# qcadoo.mes.showExceptionDetails=false # Spring Boot default is false for production (error page)
+# qcadoo.mes.passwordEncoder=bcrypt # This will be handled by Spring Security config
+
+# Note on QCADOO_CONF:
+# The strategy is to move configurations into Spring Boot's standard mechanisms
+# (application.properties, profiles, environment variables, or dedicated config server for secrets)
+# rather than relying on an external QCADOO_CONF directory structure for the new application.
+# Specific files like ESAPI properties might need special handling to be loaded from a secure, external location.
+
+# Hikari specific settings from db.properties (already covered by spring.datasource.hikari.*)
+# hikariMaximumPoolSize=15
+# hikariConnectionTimeout=30000
+# hikariIdleTimeout=600000
+# hikariMaxLifetime=1800000

--- a/mes-springboot-application/mes-app-core/src/main/resources/logback-spring.xml
+++ b/mes-springboot-application/mes-app-core/src/main/resources/logback-spring.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="springAppName" source="spring.application.name" defaultValue="mes-springboot-app"/>
+
+    <!-- Example console appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <!-- Example file appender -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/${springAppName}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>logs/${springAppName}-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <!-- each file should be at most 100MB, keep 30 days worth of history, but at most 3GB -->
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <!--
+        The original log4j.xml had many specific appenders for different packages/categories:
+        - root-log, model-log, plugin-log, view-log, localization-log, security-log,
+        - security-events-log, report-log, connector-log, activity-log, warn-log,
+        - translation-log, performance-log, sql-log, cache-log, cfg-log, tool-log.
+
+        These can be translated to Logback loggers. For example:
+    -->
+
+    <logger name="com.qcadoo.mes.springboot" level="DEBUG"/>
+    <logger name="com.qcadoo.model" level="INFO" additivity="false">
+        <!-- <appender-ref ref="MODEL_FILE_APPENDER"/> --> <!-- Define MODEL_FILE_APPENDER similarly to FILE -->
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/> <!-- Or a specific model log file -->
+    </logger>
+    <logger name="org.hibernate.SQL" level="INFO" additivity="false">
+        <!-- <appender-ref ref="SQL_FILE_APPENDER"/> --> <!-- Define SQL_FILE_APPENDER -->
+         <appender-ref ref="CONSOLE"/>
+         <appender-ref ref="FILE"/> <!-- Or a specific SQL log file -->
+    </logger>
+    <logger name="org.springframework.security" level="INFO"/>
+
+    <!-- Default root logger -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+
+    <!--
+        Note on QCADOO_LOG environment variable:
+        The original log4j.xml used ${QCADOO_LOG}/filename.log.
+        In this Logback configuration, paths are relative to the application startup
+        or can be made absolute. If an external log directory is needed,
+        you can define a property (e.g., from an environment variable or system property)
+        and use it in the file paths, e.g., <file>${LOG_DIR}/${springAppName}.log</file>.
+        Spring Boot's logging.file.path or logging.file.name in application.properties
+        can also control the main log file location.
+    -->
+
+</configuration>

--- a/mes-springboot-application/mes-plugins-column-extension/pom.xml
+++ b/mes-springboot-application/mes-plugins-column-extension/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.qcadoo.mes</groupId>
+        <artifactId>mes-springboot-application</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mes-plugins-column-extension-springboot</artifactId> <!-- Added -springboot to differentiate -->
+    <packaging>jar</packaging>
+
+    <name>Qcadoo MES :: Plugins :: Column Extension (Spring Boot)</name>
+
+    <dependencies>
+        <!-- Basic Spring Boot starter -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- Spring Boot Test starter for unit/integration tests -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
+            No Qcadoo specific dependencies are included here initially.
+            The aim is to refactor the functionality using Spring Boot principles.
+            If any core non-framework Qcadoo utilities are identified as essential
+            and hard to replicate, they might be added later as standard library dependencies.
+            The original mes-plugins-column-extension/pom.xml had no explicit dependencies,
+            relying on the qcadoo-plugin packaging and parent POMs.
+        -->
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This module will be a JAR, built as part of the larger application.
+                 No need for the spring-boot-maven-plugin here if it's not an executable JAR itself.
+                 The executable JAR will be assembled at the mes-app-core or a dedicated assembly module level.
+            -->
+        </plugins>
+    </build>
+</project>

--- a/mes-springboot-application/mes-plugins-column-extension/src/test/java/com/qcadoo/mes/columnextension/ColumnExtensionServiceSpringBootTest.java
+++ b/mes-springboot-application/mes-plugins-column-extension/src/test/java/com/qcadoo/mes/columnextension/ColumnExtensionServiceSpringBootTest.java
@@ -1,0 +1,26 @@
+package com.qcadoo.mes.columnextension;
+
+// import org.junit.jupiter.api.Test;
+// import org.springframework.boot.test.context.SpringBootTest;
+
+// @SpringBootTest // Uncomment once there's a Spring context to test
+class ColumnExtensionServiceSpringBootTest {
+
+    // @Test // Uncomment once there are methods to test
+    void contextLoads() {
+        // This test will pass if the Spring application context can be loaded (if @SpringBootTest is active)
+    }
+
+    // Placeholder for future tests
+    // @Test
+    // void testSomeFunctionality() {
+    //     // Given
+    //     // ColumnExtensionService service = new ColumnExtensionServiceImpl(); // Or inject with Spring
+    //
+    //     // When
+    //     // var result = service.someMethod();
+    //
+    //     // Then
+    //     // assertEquals(expected, result);
+    // }
+}

--- a/mes-springboot-application/pom.xml
+++ b/mes-springboot-application/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.qcadoo.mes</groupId>
+    <artifactId>mes-springboot-application</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging> <!-- Changed to pom as this will be a multi-module parent -->
+
+    <name>Qcadoo MES Spring Boot Application</name>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+    </properties>
+
+    <modules>
+        <!-- Modules will be added here later, e.g., the main application module and plugin modules -->
+        <module>mes-app-core</module> <!-- Adding a core module for the Spring Boot app itself -->
+        <module>mes-plugins-column-extension</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Dependencies common to all modules can be managed here -->
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>


### PR DESCRIPTION
- Created a new multi-module Maven project `mes-springboot-application`.
- Added `mes-app-core` module with Spring Boot 3.2.0, Java 17, and basic web starter.
- Added `mes-plugins-column-extension-springboot` as the first pilot module for migration (currently empty shell).
- Established initial `application.properties` with DB and mail placeholders.
- Added `logback-spring.xml` for logging configuration.
- Set up POMs for executable JAR packaging for `mes-app-core`.
- Created placeholder test class for the pilot module.

This commit lays the foundational structure for the incremental refactoring of the Qcadoo MES application to Spring Boot.